### PR TITLE
use ofLax instead of ofNone so that site works on localhost

### DIFF
--- a/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
@@ -71,7 +71,7 @@ public class SecurityConfiguration {
         if (sameSiteEnabled) {
             return CookieSameSiteSupplier.ofStrict();
         } else {
-            return CookieSameSiteSupplier.ofNone();
+            return CookieSameSiteSupplier.ofLax();
         }
 
     }

--- a/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
@@ -25,7 +25,7 @@ public class SecurityConfiguration {
     @Value("${csrfEnabled:false}")
     public boolean csrfEnabled;
 
-    @Value("${sameSiteEnabled:'lax'}") // strict, lax, none
+    @Value("${sameSiteEnabled:lax}") // strict, lax, none
     public String sameSiteEnabled;
 
     @Value("${httpOnlyCookiesEnabled:false}")

--- a/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
@@ -25,8 +25,8 @@ public class SecurityConfiguration {
     @Value("${csrfEnabled:false}")
     public boolean csrfEnabled;
 
-    @Value("${sameSiteEnabled:false}")
-    public boolean sameSiteEnabled;
+    @Value("${sameSiteEnabled:'lax'}") // strict, lax, none
+    public String sameSiteEnabled;
 
     @Value("${httpOnlyCookiesEnabled:false}")
     public boolean httpOnlyCookiesEnabled;
@@ -67,11 +67,15 @@ public class SecurityConfiguration {
 
     @Bean
     public CookieSameSiteSupplier applicationCookieSameSiteSupplier() {
-        log.info("Is samesite protection enabled '{}'", sameSiteEnabled);
-        if (sameSiteEnabled) {
+        log.info("Samesite mode set as '{}'", sameSiteEnabled);
+        if (sameSiteEnabled == "strict") {
             return CookieSameSiteSupplier.ofStrict();
-        } else {
+        } else if (sameSiteEnabled == "lax") {
             return CookieSameSiteSupplier.ofLax();
+        } else if (sameSiteEnabled == "none") {
+            return CookieSameSiteSupplier.ofNone();
+        } else {
+            throw new IllegalStateException("sameSiteEnabled must be strict, lax, or none");
         }
 
     }

--- a/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/jisc/cybersec/secure/SecurityConfiguration.java
@@ -68,11 +68,11 @@ public class SecurityConfiguration {
     @Bean
     public CookieSameSiteSupplier applicationCookieSameSiteSupplier() {
         log.info("Samesite mode set as '{}'", sameSiteEnabled);
-        if (sameSiteEnabled == "strict") {
+        if (sameSiteEnabled.equals("strict")) {
             return CookieSameSiteSupplier.ofStrict();
-        } else if (sameSiteEnabled == "lax") {
+        } else if (sameSiteEnabled.equals("lax")) {
             return CookieSameSiteSupplier.ofLax();
-        } else if (sameSiteEnabled == "none") {
+        } else if (sameSiteEnabled.equals("none")) {
             return CookieSameSiteSupplier.ofNone();
         } else {
             throw new IllegalStateException("sameSiteEnabled must be strict, lax, or none");


### PR DESCRIPTION
https://stackoverflow.com/questions/60069054/how-to-overcome-the-effect-of-chromes-samesite-cookie-update-in-the-case-of-loc

> Unfortunately all cookies with SameSite=None must have a Secure parameter as well

Setting `ofNone` does not set the secure parameter. It's simply easier to use `ofLax`

[build](https://tmp.duti.dev/vulnerable-webapp-1.5.2-SNAPSHOT.jar)